### PR TITLE
Docs: Translate unstable_noStore

### DIFF
--- a/docs/app-router/02-api-reference/03-functions/unstable_noStore.md
+++ b/docs/app-router/02-api-reference/03-functions/unstable_noStore.md
@@ -1,8 +1,43 @@
 ---
-title: unstable_noStore 🚧
-description: ''
+title: unstable_noStore
+description: unstable_noStore 関数の API リファレンス
 ---
 
-:::caution
-本ページは未翻訳です。翻訳され次第、順次公開予定です。
-:::
+`unstable_noStore` を使用すると、静的レンダリングを宣言的にオプトアウトし、特定のコンポーネントをキャッシュすべきでないことを示すことができます。
+
+```jsx
+import { unstable_noStore as noStore } from 'next/cache';
+
+export default async function Component() {
+  noStore();
+  const result = await db.query(...);
+  ...
+}
+```
+
+> **Good to know**:
+>
+> - `unstable_noStore` は、`fetch` 時の `cache: 'no-store'` と等価です。
+> - より細かい粒度でコンポーネントごとに使用できるため、`export const dynamic = 'force-dynamic'` よりも、`unstable_noStore` の方が好ましいです。
+
+- [`unstable_cache`](/docs/app-router/api-reference/functions/unstable_cache) の内部で `unstable_noStore` を使用しても、静的生成は行われません。代わりに、結果をキャッシュするかどうかの判断をキャッシュの設定に委ねます。
+
+## 使用方法
+
+`cache: 'no-store'` や `next: { revalidate: 0 }` のように、`fetch` 時に追加のオプションを渡したくない場合は、全てのユースケースの代替として `noStore()` を使用することができます。
+
+```jsx
+import { unstable_noStore as noStore } from 'next/cache';
+
+export default async function Component() {
+  noStore();
+  const result = await db.query(...);
+  ...
+}
+```
+
+## バージョン履歴
+
+| Version   | Changes                              |
+| --------- | ------------------------------------ |
+| `v14.0.0` | `unstable_noStore` が導入されました. |


### PR DESCRIPTION
#### Description

[unstable_noStore](https://nextjs.org/docs/app/api-reference/functions/unstable_noStore)の翻訳

#### Related Issue

Closes #50 

#### Results

[unstable_noStore _ Next.js 公式ドキュメント 日本語翻訳プロジェクト.pdf](https://github.com/openstandia/Nextjs-docs-ja/files/14189994/unstable_noStore._.Next.js.pdf)

