### PR TITLE
Docs: Translate generateSitemaps

### DIFF
--- a/docs/app-router/02-api-reference/03-functions/generate-sitemaps.md
+++ b/docs/app-router/02-api-reference/03-functions/generate-sitemaps.md
@@ -1,8 +1,52 @@
 ---
-title: generateSitemaps 🚧
-description: ''
+title: generateSitemaps
+nav_title: generateSitemaps
+description: generateSiteMaps関数を使用して、アプリケーション用に複数のサイトマップを作成する方法を説明します
+related:
+  title: 次のステップ
+  description: Next.jsアプリケーションのサイトマップを作成する方法をご紹介します
+  links:
+    - app-router/api-reference/file-conventions/metadata/sitemap
 ---
 
-:::caution
-本ページは未翻訳です。翻訳され次第、順次公開予定です。
-:::
+`generateSitemaps` 関数を使用すると、アプリケーション用に複数のサイトマップを生成できます。
+
+## Returns
+
+`generateSitemaps` は、`id` プロパティを持つオブジェクトの配列を返します。
+
+## URLs
+
+本番環境では、生成されたサイトマップは `/.../sitemap/[id].xml` で利用できるようになります。例えば、`/product/sitemap/1.xml` です。
+
+開発環境では、生成されたサイトマップを `/.../sitemap.xml/[id]` で見ることができます。例えば、`/product/sitemap.xml/1` です。この違いは一時的なもので、本番用のフォーマットに従います。
+
+## 例
+
+例えば、`generateSitemaps` を使用してサイトマップを分割するには、サイトマップの `id` を持つオブジェクトの配列を返します。そして、ユニークなサイトマップを生成するために `id` を使用します。
+
+```ts title="app/product/sitemap.ts"
+import { BASE_URL } from '@/app/lib/constants'
+
+export async function generateSitemaps() {
+  // 総数を取得し、必要なサイトマップの数を計算する
+  return [{ id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }]
+}
+
+export default async function sitemap({
+  id,
+}: {
+  id: number
+}): MetadataRoute.Sitemap {
+  // Google のサイトマップは 50,000 URL が上限
+  const start = id * 50000
+  const end = start + 50000
+  const products = await getProducts(
+    `SELECT id, date FROM products WHERE id BETWEEN ${start} AND ${end}`
+  )
+  return products.map((product) => ({
+    url: `${BASE_URL}/product/${product.id}`
+    lastModified: product.date,
+  }))
+}
+```


### PR DESCRIPTION
#### Description

[generateSitemaps](https://nextjs.org/docs/app/api-reference/functions/generate-sitemaps)の翻訳

#### Related Issue

Closes #39 

#### Results

[generateSitemaps _ Next.js 公式ドキュメント 日本語翻訳プロジェクト.pdf](https://github.com/openstandia/Nextjs-docs-ja/files/14254809/generateSitemaps._.Next.js.pdf)
