### PR TITLE
Docs: Translatenext.config.js Options / pagesExtensions

### DIFF
--- a/docs/app-router/02-api-reference/04-next-config-js/pageExtensions.md
+++ b/docs/app-router/02-api-reference/04-next-config-js/pageExtensions.md
@@ -1,8 +1,24 @@
 ---
-title: pageExtensions 🚧
-description: Extend the default page extensions used by Next.js when resolving pages in the Pages Router.
+title: pageExtensions
+description: Pagesルーターでページを解決するときにNext.jsが使用するデフォルトのページ拡張子を拡張します
 ---
 
-:::caution
-本ページは未翻訳です。翻訳され次第、順次公開予定です。
-:::
+By default, Next.js accepts files with the following extensions: `.tsx`, `.ts`, `.jsx`, `.js`.
+This can be modified to allow other extensions like markdown (`.md`, `.mdx`).
+
+デフォルトでは、Next.js は次の拡張子のファイルを受け入れます: `.tsx`、`.ts`、`.jsx`、`.js`です。
+マークダウン（`.md`、`.mdx`）のような他の拡張子を許可するように変更することもできます。
+
+```js title="next.config.js"
+const withMDX = require('@next/mdx')()
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  pageExtensions: ['ts', 'tsx', 'mdx'],
+  experimental: {
+    mdxRs: true,
+  },
+}
+
+module.exports = withMDX(nextConfig)
+```


### PR DESCRIPTION
#### Description

[pagesExtensions](https://nextjs.org/docs/app/api-reference/next-config-js/pageExtensions)の翻訳

#### Related Issue

Closes #56  

#### Results

[pageExtensions _ Next.js 公式ドキュメント 日本語翻訳プロジェクト.pdf](https://github.com/openstandia/Nextjs-docs-ja/files/14303459/pageExtensions._.Next.js.pdf)
