### PR TITLE
#53 Translate logging

### DIFF
--- a/docs/app-router/02-api-reference/04-next-config-js/logging.md
+++ b/docs/app-router/02-api-reference/04-next-config-js/logging.md
@@ -1,8 +1,18 @@
 ---
-title: logging 🚧
-description: ''
+title: ロギング
+description: 開発モードで Next.js を実行する際のデータフェッチのログ出力設定方法
 ---
 
-:::caution
-本ページは未翻訳です。翻訳され次第、順次公開予定です。
-:::
+Next.js を開発モードで実行しているときに、完全な URL がコンソールにログ出力されるかどうかと、ログレベル設定ができます。
+
+現在、`logging` は `fetch` APIを使用したデータフェッチにのみ適用されます。 Next.js 内の他のログにはまだ適用されません。
+
+```js title="next.config.js"
+module.exports = {
+  logging: {
+    fetches: {
+      fullUrl: true,
+    },
+  },
+}
+```

--- a/docs/app-router/02-api-reference/04-next-config-js/logging.md
+++ b/docs/app-router/02-api-reference/04-next-config-js/logging.md
@@ -1,5 +1,5 @@
 ---
-title: ロギング
+title: logging
 description: 開発モードで Next.js を実行する際のデータフェッチのログ出力設定方法
 ---
 


### PR DESCRIPTION
## Description

[logging](https://nextjs.org/docs/app/api-reference/next-config-js/logging)の翻訳

## Related issue

closes #53 