### PR TITLE
#88 configuring/absolute-imports-and-module-aliases

### DIFF
--- a/docs/app-router/01-building-your-application/07-configuring/04-absolute-imports-and-module-aliases.md
+++ b/docs/app-router/01-building-your-application/07-configuring/04-absolute-imports-and-module-aliases.md
@@ -1,8 +1,125 @@
 ---
-title: Absolute Imports and Module Path Aliases 🚧
-description: ''
+title: 絶対インポートとモジュール・パス・エイリアス
+description: 特定のインポートパスをリマップするためのモジュール・パス・エイリアスを設定します。
 ---
 
-:::caution
-本ページは未翻訳です。翻訳され次第、順次公開予定です。
-:::
+<details>
+  <summary>例</summary>
+
+- [絶対インポートとエイリアス](https://github.com/vercel/next.js/tree/canary/examples/with-absolute-imports)
+
+</details>
+
+Next.jsは `tsconfig.json` と `jsconfig.json` のオプション `"paths"`と `"baseUrl"`をサポートしています。
+
+これらのオプションを使うと、プロジェクトディレクトリを絶対パスにエイリアスでき、モジュールのインポートが簡単になります。例えば:
+
+```tsx
+// 変更前
+import { Button } from '../../../components/button'
+
+// 変更後
+import { Button } from '@/components/button'
+```
+
+> **Good to know**: `create-next-app` はこれらのオプションを設定するようにプロンプトします。
+
+## 絶対インポート
+
+`baseUrl` 設定オプションを使うと、プロジェクトのルートから直接インポートできます。
+
+設定の例:
+
+```json title="tsconfig.json または jsconfig.json"
+{
+  "compilerOptions": {
+    "baseUrl": "."
+  }
+}
+```
+
+```jsx title="components/button.tsx"
+export default function Button() {
+  return <button>Click me</button>
+}
+```
+
+```tsx title="app/page.tsx"
+import Button from 'components/button'
+
+export default function HomePage() {
+  return (
+    <>
+      <h1>Hello World</h1>
+      <Button />
+    </>
+  )
+}
+```
+
+## モジュールエイリアス
+
+`baseUrl` パスを設定するうえで、`"paths"`オプションを使ってモジュールパスを"エイリアス化"できます。
+
+例えば、次の設定では、`@/components/*`を`components/*`にマップします:
+
+```json title="tsconfig.json または jsconfig.json"
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["components/*"]
+    }
+  }
+}
+```
+
+```tsx title="components/button.tsx"
+export default function Button() {
+  return <button>Click me</button>
+}
+```
+
+```tsx title="app/page.tsx"
+import Button from '@/components/button'
+
+export default function HomePage() {
+  return (
+    <>
+      <h1>Hello World</h1>
+      <Button />
+    </>
+  )
+}
+```
+
+`"paths"` の各指定は、`baseUrl` の位置に対して相対的です。例えば:
+
+```json
+// tsconfig.json または jsconfig.json
+{
+  "compilerOptions": {
+    "baseUrl": "src/",
+    "paths": {
+      "@/styles/*": ["styles/*"],
+      "@/components/*": ["components/*"]
+    }
+  }
+}
+```
+
+```jsx
+// pages/index.js
+import Button from '@/components/button'
+import '@/styles/styles.css'
+import Helper from 'utils/helper'
+
+export default function HomePage() {
+  return (
+    <Helper>
+      <h1>Hello World</h1>
+      <Button />
+    </Helper>
+  )
+}
+```


### PR DESCRIPTION
## Description

[Absolute Imports and Module Path Aliases](https://nextjs.org/docs/app/building-your-application/configuring/absolute-imports-and-module-aliases)の翻訳

## Related issue

closes #88 