### PR TITLE
Fix typo

### DIFF
--- a/docs/app-router/01-building-your-application/03-rendering/03-composition-patterns.md
+++ b/docs/app-router/01-building-your-application/03-rendering/03-composition-patterns.md
@@ -370,7 +370,7 @@ export default function ClientComponent({
 
 ```tsx title="app/page.tsx"
 // このパターンは動作する：
-// Client ComponentのchildまたはpropとしてSevrer Componentを渡す
+// Client ComponentのchildまたはpropとしてServer Componentを渡す
 import ClientComponent from './client-component'
 import ServerComponent from './server-component'
 

--- a/docs/app-router/01-building-your-application/04-caching/index.md
+++ b/docs/app-router/01-building-your-application/04-caching/index.md
@@ -355,7 +355,7 @@ Router Cache は無効にできません。[`router.refresh`](/docs/app-router/a
 ### Data Cache と クライアントサイドの Router Cache
 
 - [Route Handler](/docs/app-router/building-your-application/routing/route-handlers)の Data Cache を再有効化しても、Route Handler は特定のルートに結びついていないので、Router Cache はすぐには無効化**されません**。つまり、Router Cache はハードリフレッシュされるか、自動無効化期間が経過するまで、以前のペイロードを提供し続けます
-- Data Cache と Router Cache を直ちに無効にするには、[Sevrer Action](/docs/app-router/building-your-application/data-fetching/server-actions-and-mutations) で [`revalidatePath`](#revalidatepath) または [`revalidateTag`](#fetch-optionsnexttags-と-revalidatetag) を使用します
+- Data Cache と Router Cache を直ちに無効にするには、[Server Action](/docs/app-router/building-your-application/data-fetching/server-actions-and-mutations) で [`revalidatePath`](#revalidatepath) または [`revalidateTag`](#fetch-optionsnexttags-と-revalidatetag) を使用します
 
 ## API
 


### PR DESCRIPTION
I fixed typos on the following two pages:

1. **[caching page](https://ja.next-community-docs.dev/docs/app-router/building-your-application/caching/)**
   - Before: "Sevrer"
   - After: "Server"

2. **[composition patterns page](https://ja.next-community-docs.dev/docs/app-router/building-your-application/rendering/composition-patterns)**
   - Before: "Sevrer"
   - After: "Server"

