### PR TITLE
chore: fix image download (#369)

### DIFF
--- a/scripts/konjacbot/dlimg.mts
+++ b/scripts/konjacbot/dlimg.mts
@@ -65,9 +65,13 @@ async function downloadImage(
   index: number,
   imagePathList: string[]
 ): Promise<void> {
+  //例：https://nextjs.org/_next/image?url=https%3A%2F%2Fh8DxKfmAPhn8O0p3.public.blob.vercel-storage.com%2Fdocs%2Fdark%2Ftypescript-command-palette.png&w=1920&q=75
   const searchPrams = new URLSearchParams()
-  searchPrams.append('url', imagePath)
-  searchPrams.append('w', '3840')
+  searchPrams.append(
+    'url',
+    `https://h8DxKfmAPhn8O0p3.public.blob.vercel-storage.com${imagePath}`
+  )
+  searchPrams.append('w', '1920')
   searchPrams.append('q', '75')
   const url = new URL(
     `${defaults.downloadEndpoint}?${searchPrams.toString()}`


### PR DESCRIPTION
konjacbotが失敗している問題の対応

### 失敗内容：
https://github.com/openstandia/Nextjs-docs-ja/actions/runs/14025990219/job/39264647626

### 原因と対応内容：
画像のダウンロードURLが変更されていたため。画像取得先を以下のような形式に変更
https://nextjs.org/_next/image?url=https%3A%2F%2Fh8DxKfmAPhn8O0p3.public.blob.vercel-storage.com%2Fdocs%2Fdark%2Ftypescript-command-palette.png&w=1920&q=75

### 上記変更後の動作確認エビデンス：
GitHubAction：https://github.com/openstandia/Nextjs-docs-ja/actions/runs/14028666757
PR：https://github.com/openstandia/Nextjs-docs-ja/pull/371

